### PR TITLE
fix: Set X-Requested-With header on all requests to avoid browser auth dialogs

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,6 +13,7 @@ interface CancelableAxiosInstance extends AxiosInstance {
 const client = Axios.create({
 	headers: {
 		requesttoken: getRequestToken() ?? '',
+		'X-Requested-With': 'XMLHttpRequest',
 	},
 })
 const cancelableClient: CancelableAxiosInstance = Object.assign(client, {


### PR DESCRIPTION
Server has logic in place to return a dummyauth response header in case this one is set:
https://github.com/nextcloud/server/commit/dfc3536d2b95fea1b54b3e85651e3a66c2d0088e

This helps to handle requests that happen in the web UI after authentication was revoked (e.g. by disabling a user) more gracefully, otherwise a request would lead to the browser showing a basic auth dialog.

Steps to reproduce:
- Login as a user
- Disable the user through occ
- Wait until the notifications app sends another request