### PR TITLE
chore: Prepare 2.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,22 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## 2.4.0 – 2023-06-28
+## 2.5.0 - 2024-04-30
+### Added
+* Export `isAxiosError` and Axios types - So in most cases you do not need to also depend on vanilla Axios
 
+### Fixed
+* fix: Set X-Requested-With header on all requests to avoid browser auth dialogs
+
+### Changed
+* Update NPM to v10 for LTS Node version 20
+* Bump axios from 1.5.0 to 1.6.8
+* Bump @nextcloud/router from 2.1.2 to 3.0.1
+* Bump @nextcloud/auth from 2.1.0 to 2.3.0
+* Migrate to vite and vitest
+* Adjust badges and links in README
+
+## 2.4.0 – 2023-06-28
 ### Fixed
 - Fix package exports to allow Typescript projects with module
   resolution of `Node16` or `NodeNext` to import the package

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/axios",
-  "version": "3.0.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/axios",
-      "version": "3.0.0",
+      "version": "2.5.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@nextcloud/auth": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/axios",
-  "version": "3.0.0",
+  "version": "2.5.0",
   "description": "Axios client for Nextcloud",
   "types": "dist/index.d.ts",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## 2.5.0 - 2024-04-30
### Added
* Export `isAxiosError` and Axios types - So in most cases you do not need to also depend on vanilla Axios

### Fixed
* fix: Set X-Requested-With header on all requests to avoid browser auth dialogs

### Changed
* Update NPM to v10 for LTS Node version 20
* Bump axios from 1.5.0 to 1.6.8
* Bump @nextcloud/router from 2.1.2 to 3.0.1
* Bump @nextcloud/auth from 2.1.0 to 2.3.0
* Migrate to vite and vitest
* Adjust badges and links in README