### PR TITLE
chore: prepare v2.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 2.5.2 - 2025-09-13
+### Fixed
+* fix: add missing config interface typing for `reloadExpiredSession`
+
+### Changed
+* refactor: add SPDX headers
+* refactor: migrate REUSE to TOML format
+* refactor: resolve Typescript errors and stabilize tests
+* chore: migrate to ESLint v9
+* chore: allow wider `engine` version range
+* chore: adjust `package.json`
+  * make order consistent with other libraries
+  * update maintainer information
+  * fix wrong URLs
+* ci: update reuse.yml workflow from organization
+* ci: update npm-publish.yml workflow from template
+* ci: update workflows from organization
+* Bump `@nextcloud/auth` to 2.5.1
+* Bump `axios` to 1.12.1
+
 ## 2.5.1 - 2024-09-18
 ### Fixed
 * Make license info SPDX compliant: GPL-3.0-or-later

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/axios",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/axios",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/axios",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Axios client for Nextcloud",
   "keywords": [
     "nextcloud",


### PR DESCRIPTION
## 2.5.2
### Fixed
* fix: add missing config interface typing for `reloadExpiredSession`

### Changed
* Add SPDX headers
* Migrate REUSE to TOML format
* chore: migrate to ESLint v9
* chore: allow wider `engine` version range
* chore: adjust `package.json`
  * make order consistent with other libraries
  * update maintainer information
  * fix wrong URLs
* ci: update reuse.yml workflow from organization
* ci: update npm-publish.yml workflow from template
* ci: update workflows from organization
* Bump @nextcloud/auth to 2.5.1
* Bump axios to 1.12.1